### PR TITLE
Handle arbitrary payload

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "unfeed",
-  "version": "1.0.5",
+  "version": "1.0.6",
   "license": "Apache-2.0",
   "repository": {
     "type": "git",

--- a/src/index.ts
+++ b/src/index.ts
@@ -30,9 +30,9 @@ function init() {
   document.querySelectorAll("[data-unfeed-button]").forEach((el) => {
     if (!(el instanceof HTMLElement)) return;
 
-    // Infer config from data attributes
-    const dataset = el.dataset as Record<string, string>;
-    if (dataset.unfeedOpen !== undefined) open(el, dataset);
+    // Infer config from dataset
+    const dataset = el.dataset;
+    if (dataset.unfeedOpen !== undefined) open(el);
     if (dataset.unfeedFooter !== undefined)
       config.footer = dataset.unfeedFooter;
 
@@ -44,9 +44,7 @@ function init() {
       );
     }
 
-    el.addEventListener("click", (e: Event) =>
-      open(e.target as HTMLElement, dataset)
-    );
+    el.addEventListener("click", (e: Event) => open(e.target as HTMLElement));
   });
 }
 window.addEventListener("load", init);
@@ -59,7 +57,7 @@ const trap = createFocusTrap(containerElement, {
   allowOutsideClick: true,
 });
 
-function open(target: HTMLElement, dataset: Record<string, string>) {
+function open(target: HTMLElement) {
   document.body.appendChild(containerElement);
   containerElement.innerHTML = formHTML;
   containerElement.style.display = "block";
@@ -89,7 +87,7 @@ function open(target: HTMLElement, dataset: Record<string, string>) {
 
   document
     .getElementById("unfeed__form")!
-    .addEventListener("submit", (e) => submit(e, dataset));
+    .addEventListener("submit", (e) => submit(e, target));
 }
 
 function close() {
@@ -114,11 +112,12 @@ function changeType(e: Event) {
   feedback.focus();
 }
 
-function submit(e: Event, dataset: Record<string, string>) {
+function submit(e: Event, buttonElement: HTMLElement) {
   e.preventDefault();
   const target = e.target as HTMLFormElement;
 
   // Merge latest values from dataset to config
+  const dataset = buttonElement.dataset as Record<string, string>;
   if (dataset.unfeedButton) config.url = dataset.unfeedButton;
   if (dataset.unfeedName) config.user.name = dataset.unfeedName;
   if (dataset.unfeedEmail) config.user.email = dataset.unfeedEmail;

--- a/src/index.ts
+++ b/src/index.ts
@@ -159,7 +159,7 @@ function submit(e: Event, dataset: Record<string, string>) {
   fetch(config.url, {
     headers: { "Content-Type": "application/json" },
     method: "POST",
-    mode: dataset.unfeedCorsMode as RequestMode | undefined,
+    mode: (dataset.unfeedCorsMode || "no-cors") as RequestMode | undefined,
     body: JSON.stringify(data),
   })
     .then(() => containerElement.setAttribute("data-success", ""))

--- a/src/index.ts
+++ b/src/index.ts
@@ -10,6 +10,7 @@ export type UnfeedConfig = {
   disableErrorAlert: boolean;
   context?: string;
   footer?: string;
+  payload?: Record<string, string>;
 };
 const config: UnfeedConfig = {
   url: "",
@@ -30,14 +31,10 @@ function init() {
     if (!(el instanceof HTMLElement)) return;
 
     // Infer config from data attributes
-    const dataset = el.dataset;
-    if (dataset.unfeedButton) config.url = dataset.unfeedButton;
-    if (dataset.unfeedName) config.user.name = dataset.unfeedName;
-    if (dataset.unfeedEmail) config.user.email = dataset.unfeedEmail;
-    if (dataset.unfeedContext) config.context = dataset.unfeedContext;
+    const dataset = el.dataset as Record<string, string>;
+    if (dataset.unfeedOpen !== undefined) open(el, dataset);
     if (dataset.unfeedFooter !== undefined)
       config.footer = dataset.unfeedFooter;
-    if (dataset.unfeedOpen !== undefined) open(el);
 
     // Customize primary color
     if (dataset.unfeedPrimaryColor) {
@@ -47,7 +44,9 @@ function init() {
       );
     }
 
-    el.addEventListener("click", (e: Event) => open(e.target as HTMLElement));
+    el.addEventListener("click", (e: Event) =>
+      open(e.target as HTMLElement, dataset)
+    );
   });
 }
 window.addEventListener("load", init);
@@ -60,11 +59,12 @@ const trap = createFocusTrap(containerElement, {
   allowOutsideClick: true,
 });
 
-function open(target: HTMLElement) {
+function open(target: HTMLElement, dataset: Record<string, string>) {
   document.body.appendChild(containerElement);
   containerElement.innerHTML = formHTML;
   containerElement.style.display = "block";
 
+  // Customize footer
   if (config.footer !== undefined) {
     containerElement.querySelector("#unfeed__footer")!.innerHTML =
       config.footer;
@@ -87,7 +87,9 @@ function open(target: HTMLElement) {
     (el) => el.addEventListener("change", changeType)
   );
 
-  document.getElementById("unfeed__form")!.addEventListener("submit", submit);
+  document
+    .getElementById("unfeed__form")!
+    .addEventListener("submit", (e) => submit(e, dataset));
 }
 
 function close() {
@@ -112,14 +114,32 @@ function changeType(e: Event) {
   feedback.focus();
 }
 
-function submit(e: Event) {
+function submit(e: Event, dataset: Record<string, string>) {
   e.preventDefault();
   const target = e.target as HTMLFormElement;
 
+  // Merge latest values from dataset to config
+  if (dataset.unfeedButton) config.url = dataset.unfeedButton;
+  if (dataset.unfeedName) config.user.name = dataset.unfeedName;
+  if (dataset.unfeedEmail) config.user.email = dataset.unfeedEmail;
+  if (dataset.unfeedContext) config.context = dataset.unfeedContext;
+
+  // If specified, include arbitrary payload as key value
+  const prefix = "unfeedPayload";
+  for (const key in dataset) {
+    if (key.startsWith(prefix)) {
+      // Transform `unfeedPayloadSomeKey` into `someKey`
+      const payloadName =
+        key.charAt(prefix.length).toLowerCase() + key.slice(prefix.length + 1);
+      config.payload = { ...config.payload, [payloadName]: dataset[key] };
+    }
+  }
+
   if (!config.url) {
     console.error("Unfeed: No URL provided");
-    if (!config.disableErrorAlert)
+    if (!config.disableErrorAlert) {
       alert("Could not send feedback: No URL provided");
+    }
     return;
   }
 
@@ -127,20 +147,19 @@ function submit(e: Event) {
   submitElement.setAttribute("disabled", "");
   submitElement.innerHTML = "Sending..";
 
-  const myHeaders = new Headers();
-  myHeaders.append("Content-Type", "application/json");
-
   const data = {
     ...config.user,
     feedbackType: (target.elements as any).feedbackType.value,
     message: (target.elements as any).message.value,
-    context: config.context,
     timestamp: Date.now(),
+    context: config.context,
+    payload: config.payload,
   };
 
   fetch(config.url, {
+    headers: { "Content-Type": "application/json" },
     method: "POST",
-    headers: myHeaders,
+    mode: dataset.unfeedCorsMode as RequestMode | undefined,
     body: JSON.stringify(data),
   })
     .then(() => containerElement.setAttribute("data-success", ""))

--- a/test.html
+++ b/test.html
@@ -22,13 +22,17 @@
   <button onclick="toggleTheme()" style="position: fixed; top: 8px; left: 8px">
     Toggle theme
   </button>
+  <!-- See the submissions here: http://mockbin.org/bin/2b14c17d-71e9-43b6-914e-efb65df8409c/log -->
   <button
-    data-unfeed-button=""
+    data-unfeed-button="http://mockbin.org/bin/2b14c17d-71e9-43b6-914e-efb65df8409c"
     data-unfeed-name="John Doe"
     data-unfeed-email="john@example.com"
     data-unfeed-primary-color="#31ba64"
     data-unfeed-context="test at localhost"
     data-unfeed-footer="Hello world!"
+    data-unfeed-payload-is-user="true"
+    data-unfeed-payload-is-logged-in="false"
+    data-unfeed-cors-mode="no-cors"
   >
     Send Feedback
   </button>


### PR DESCRIPTION
- [x] Allow passing `data-unfeed-payload-*` to add json payload in request
- [x] Add `data-unfeed-cors-mode` to customize cors mode (will use `no-cors` if not specified). See [MDN](https://developer.mozilla.org/en-US/docs/Web/API/Request/mode) for docs.
- [x] Get latest dataset value before submitting